### PR TITLE
Bump actions/checkout to v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./
         id: vercel-action
         with:


### PR DESCRIPTION
Bump actions/checkout to `v3` as GitHub is deprecating the `save-state` and `set-output` commands for GitHub actions and will disable them on May 31, 2023 per [this blog announcement on October 11, 2022](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
> We are monitoring telemetry for the usage of these commands and plan to fully disable them on 31st May 2023. Starting 1st June 2023 workflows using `save-state` or `set-output` commands via stdout will fail with an error.