### PR TITLE
bump to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ outputs:
   preview-name:
     description: 'deployment preview name'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
This is a noop since github forces it to run on `node20` anyways:

https://github.blog/changelog/2024-03-06-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/